### PR TITLE
Fix CreateAuthUser logging redaction and add masking test

### DIFF
--- a/internal/app/command/create_auth_user.go
+++ b/internal/app/command/create_auth_user.go
@@ -48,7 +48,7 @@ func (c *CreateAuthUser) Execute(ctx context.Context, input dto.CreateAuthUserIn
 		map[string]any{
 			"trace_id": tracerID,
 			"body": logger.RedactStruct[dto.CreateAuthUserInput](input, "password",
-				"Password_confirm"),
+				"password_confirm"),
 		})
 
 	user := mapper.ToUser(input)

--- a/tests/mocks/app/mservice/user_service_mock.go
+++ b/tests/mocks/app/mservice/user_service_mock.go
@@ -1,0 +1,21 @@
+package mservice
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/andreis3/auth-ms/internal/domain/errors"
+)
+
+type UserServiceMock struct{ mock.Mock }
+
+func (s *UserServiceMock) ValidateEmailAvailability(ctx context.Context, email string) *errors.Error {
+	args := s.Called(ctx, email)
+
+	if v := args.Get(0); v != nil {
+		return v.(*errors.Error)
+	}
+
+	return nil
+}

--- a/tests/mocks/infra/madapters/bcrypt_mock.go
+++ b/tests/mocks/infra/madapters/bcrypt_mock.go
@@ -1,0 +1,25 @@
+package madapters
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/andreis3/auth-ms/internal/domain/errors"
+)
+
+type BcryptMock struct{ mock.Mock }
+
+func (b *BcryptMock) Hash(data string) (string, *errors.Error) {
+	args := b.Called(data)
+
+	var err *errors.Error
+	if v := args.Get(1); v != nil {
+		err = v.(*errors.Error)
+	}
+
+	return args.String(0), err
+}
+
+func (b *BcryptMock) CompareHash(hash, data string) bool {
+	args := b.Called(hash, data)
+	return args.Bool(0)
+}

--- a/tests/mocks/infra/madapters/utils_mock.go
+++ b/tests/mocks/infra/madapters/utils_mock.go
@@ -1,0 +1,10 @@
+package madapters
+
+import "github.com/stretchr/testify/mock"
+
+type UtilsMock struct{ mock.Mock }
+
+func (u *UtilsMock) UUID() string {
+	args := u.Called()
+	return args.String(0)
+}

--- a/tests/suts/create_auth_user_sut_types.go
+++ b/tests/suts/create_auth_user_sut_types.go
@@ -1,0 +1,40 @@
+//go:build unit
+
+package suts
+
+import (
+	"github.com/andreis3/auth-ms/internal/app/command"
+	"github.com/andreis3/auth-ms/tests/mocks/app/mservice"
+	"github.com/andreis3/auth-ms/tests/mocks/infra/madapters"
+	"github.com/andreis3/auth-ms/tests/mocks/infra/mrepository"
+)
+
+type CreateAuthUserSut struct {
+	Repo    *mrepository.UserRepositoryMock
+	Service *mservice.UserServiceMock
+	Bcrypt  *madapters.BcryptMock
+	Log     *madapters.LoggerMock
+	Tracer  *madapters.TracerMock
+	Span    *madapters.SpanMock
+	Sc      *madapters.SpanContextMock
+	Utils   *madapters.UtilsMock
+	Cmd     *command.CreateAuthUser
+}
+
+func MakeCreateAuthUserSut() *CreateAuthUserSut {
+	return &CreateAuthUserSut{
+		Repo:    new(mrepository.UserRepositoryMock),
+		Service: new(mservice.UserServiceMock),
+		Bcrypt:  new(madapters.BcryptMock),
+		Log:     new(madapters.LoggerMock),
+		Tracer:  new(madapters.TracerMock),
+		Span:    new(madapters.SpanMock),
+		Sc:      new(madapters.SpanContextMock),
+		Utils:   new(madapters.UtilsMock),
+	}
+}
+
+func (s *CreateAuthUserSut) Build() *command.CreateAuthUser {
+	s.Cmd = command.NewCreateAuthUser(s.Repo, s.Service, s.Bcrypt, s.Log, s.Tracer, s.Utils)
+	return s.Cmd
+}

--- a/tests/unit/app/command/create_auth_user_test.go
+++ b/tests/unit/app/command/create_auth_user_test.go
@@ -1,0 +1,99 @@
+//go:build unit
+
+package command_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/andreis3/auth-ms/internal/app/dto"
+	"github.com/andreis3/auth-ms/internal/app/mapper"
+	"github.com/andreis3/auth-ms/internal/domain/entity"
+	"github.com/andreis3/auth-ms/internal/domain/errors"
+	"github.com/andreis3/auth-ms/internal/domain/interfaces/adapter"
+	"github.com/andreis3/auth-ms/internal/infra/logger"
+	"github.com/andreis3/auth-ms/tests/suts"
+)
+
+var _ = Describe("INTERNAL :: APP :: COMMAND :: CREATE_AUTH_USER", func() {
+	Describe("#Execute", func() {
+		Context("success cases", func() {
+			It("should mask password fields when logging input body", func() {
+				ctx := context.Background()
+				input := dto.CreateAuthUserInput{
+					Email:           "user@example.com",
+					Password:        "Sup3r$ecretZ",
+					PasswordConfirm: "Sup3r$ecretZ",
+					Name:            "Test User",
+				}
+
+				sut := suts.MakeCreateAuthUserSut()
+
+				sut.Tracer.On("Start", ctx, "CreateAuthUser.Execute").Return(ctx, adapter.Span(sut.Span))
+				sut.Span.On("SpanContext").Return(adapter.SpanContext(sut.Sc))
+				sut.Span.On("End").Return()
+				sut.Sc.On("TraceID").Return("trace-123")
+
+				sut.Log.On("InfoJSON", mock.Anything, mock.Anything).Return()
+
+				sut.Utils.On("UUID").Return("generated-uuid")
+
+				sut.Service.On("ValidateEmailAvailability", ctx, input.Email).Return((*errors.Error)(nil))
+
+				sut.Bcrypt.On("Hash", input.Password).Return("hashed-password", (*errors.Error)(nil))
+
+				createdUser := mapper.ToUser(input)
+				createdUser.AssignPublicID("generated-uuid")
+				createdUser.AssignRole(entity.RoleUser)
+				createdUser.AssignPasswordHash("hashed-password")
+				createdUser.AssignID(1)
+
+				sut.Repo.On("CreateUser", ctx, mock.MatchedBy(func(user entity.User) bool {
+					return user.PublicID() == "generated-uuid" &&
+						user.Password() == input.Password &&
+						user.PasswordHash() == "hashed-password" &&
+						user.Email() == input.Email &&
+						user.Name() == input.Name
+				})).Return(&createdUser, (*errors.Error)(nil))
+
+				command := sut.Build()
+
+				output, err := command.Execute(ctx, input)
+
+				Expect(err).To(BeNil())
+				Expect(output).ToNot(BeNil())
+				Expect(output.PublicID).To(Equal("generated-uuid"))
+
+				Expect(sut.Log.AssertNumberOfCalls(GinkgoT(), "InfoJSON", 1)).To(BeTrue())
+				Expect(sut.Log.AssertCalled(GinkgoT(), "InfoJSON", "Creating auth user", mock.MatchedBy(func(m map[string]any) bool {
+					traceID, ok := m["trace_id"].(string)
+					if !ok || traceID != "trace-123" {
+						return false
+					}
+
+					body, ok := m["body"].(dto.CreateAuthUserInput)
+					if !ok {
+						return false
+					}
+
+					return body.Email == input.Email &&
+						body.Name == input.Name &&
+						body.Password == logger.Mask &&
+						body.PasswordConfirm == logger.Mask
+				}))).To(BeTrue())
+
+				Expect(sut.Tracer.AssertCalled(GinkgoT(), "Start", ctx, "CreateAuthUser.Execute")).To(BeTrue())
+				Expect(sut.Span.AssertCalled(GinkgoT(), "SpanContext")).To(BeTrue())
+				Expect(sut.Sc.AssertCalled(GinkgoT(), "TraceID")).To(BeTrue())
+				Expect(sut.Span.AssertCalled(GinkgoT(), "End")).To(BeTrue())
+				Expect(sut.Utils.AssertCalled(GinkgoT(), "UUID")).To(BeTrue())
+				Expect(sut.Service.AssertCalled(GinkgoT(), "ValidateEmailAvailability", ctx, input.Email)).To(BeTrue())
+				Expect(sut.Bcrypt.AssertCalled(GinkgoT(), "Hash", input.Password)).To(BeTrue())
+				Expect(sut.Repo.AssertCalled(GinkgoT(), "CreateUser", ctx, mock.AnythingOfType("entity.User"))).To(BeTrue())
+			})
+		})
+	})
+})

--- a/tests/unit/app/command/suite_test.go
+++ b/tests/unit/app/command/suite_test.go
@@ -1,0 +1,19 @@
+package command_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test_CommandSuite(t *testing.T) {
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	suiteConfig.SkipStrings = []string{"SKIPPED", "PENDING", "NEVER-RUN", "SKIP"}
+	reporterConfig.FullTrace = true
+	reporterConfig.Verbose = false
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite Tests Context", suiteConfig, reporterConfig)
+}


### PR DESCRIPTION
## Summary
- update CreateAuthUser logging to redact the password_confirm field correctly
- add mocks and a SUT helper for exercising the CreateAuthUser command in unit tests
- add a unit test that ensures both password inputs are masked when logged

## Testing
- go test ./tests/unit/... -tags=unit -v

------
https://chatgpt.com/codex/tasks/task_e_68fba1298884832eae59d7416f64c884