### PR TITLE
Fix request duration metrics and add handler tests

### DIFF
--- a/internal/adapter/input/http/helpers/response.go
+++ b/internal/adapter/input/http/helpers/response.go
@@ -36,7 +36,7 @@ func ResponseSuccess[T any](write http.ResponseWriter, status int, data T) {
 	_ = json.NewEncoder(write).Encode(result)
 }
 
-func ResponseError(write http.ResponseWriter, err *errors.Error) {
+func ResponseError(write http.ResponseWriter, err *errors.Error) int {
 	status := translator.ErrorTranslator[err.Code].HTTPStatus
 	write.Header().Set(ContentType, ApplicationJSON)
 	write.WriteHeader(status)
@@ -48,4 +48,5 @@ func ResponseError(write http.ResponseWriter, err *errors.Error) {
 	}
 
 	_ = json.NewEncoder(write).Encode(result)
+	return status
 }

--- a/tests/mocks/app/mcommand/create_auth_user_command_mock.go
+++ b/tests/mocks/app/mcommand/create_auth_user_command_mock.go
@@ -1,0 +1,27 @@
+package mcommand
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/andreis3/auth-ms/internal/app/dto"
+	"github.com/andreis3/auth-ms/internal/domain/errors"
+)
+
+type CreateAuthUserCommandMock struct{ mock.Mock }
+
+func (c *CreateAuthUserCommandMock) Execute(ctx context.Context, input dto.CreateAuthUserInput) (*dto.CreateAuthUserOutput, *errors.Error) {
+	args := c.Called(ctx, input)
+
+	var output *dto.CreateAuthUserOutput
+	if v := args.Get(0); v != nil {
+		output = v.(*dto.CreateAuthUserOutput)
+	}
+
+	if err := args.Get(1); err != nil {
+		return output, err.(*errors.Error)
+	}
+
+	return output, nil
+}

--- a/tests/mocks/infra/madapters/prometheus_mock.go
+++ b/tests/mocks/infra/madapters/prometheus_mock.go
@@ -1,0 +1,35 @@
+package madapters
+
+import (
+	"github.com/stretchr/testify/mock"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/andreis3/auth-ms/internal/domain/interfaces/adapter"
+)
+
+type PrometheusMock struct{ mock.Mock }
+
+func (p *PrometheusMock) CounterRequestStatusCode(router, protocol string, statusCode int) {
+	p.Called(router, protocol, statusCode)
+}
+
+func (p *PrometheusMock) ObserveInstructionDBDuration(database, table, method string, duration float64) {
+	p.Called(database, table, method, duration)
+}
+
+func (p *PrometheusMock) ObserveRequestDuration(router, protocol string, statusCode int, status string, duration float64) {
+	p.Called(router, protocol, statusCode, status, duration)
+}
+
+func (p *PrometheusMock) Close() {}
+
+func (p *PrometheusMock) MeterProvider() *metric.MeterProvider {
+	args := p.Called()
+	if v := args.Get(0); v != nil {
+		return v.(*metric.MeterProvider)
+	}
+
+	return nil
+}
+
+var _ adapter.Prometheus = (*PrometheusMock)(nil)

--- a/tests/unit/adapter/input/http/handler/create_auth_user_handler_test.go
+++ b/tests/unit/adapter/input/http/handler/create_auth_user_handler_test.go
@@ -1,0 +1,139 @@
+//go:build unit
+
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/andreis3/auth-ms/internal/adapter/input/http/handler"
+	"github.com/andreis3/auth-ms/internal/app/dto"
+	"github.com/andreis3/auth-ms/internal/domain/errors"
+	"github.com/andreis3/auth-ms/internal/domain/interfaces/adapter"
+	mcommand "github.com/andreis3/auth-ms/tests/mocks/app/mcommand"
+	madapters "github.com/andreis3/auth-ms/tests/mocks/infra/madapters"
+)
+
+var _ = Describe("INTERNAL :: ADAPTER :: INPUT :: HTTP :: HANDLER :: CREATE_AUTH_USER", func() {
+	const route = "/auth/signup"
+
+	var (
+		tracer      *madapters.TracerMock
+		span        *madapters.SpanMock
+		spanCtx     *madapters.SpanContextMock
+		logger      *madapters.LoggerMock
+		prometheus  *madapters.PrometheusMock
+		commandMock *mcommand.CreateAuthUserCommandMock
+	)
+
+	BeforeEach(func() {
+		tracer = &madapters.TracerMock{}
+		span = &madapters.SpanMock{}
+		spanCtx = &madapters.SpanContextMock{}
+		logger = &madapters.LoggerMock{}
+		prometheus = &madapters.PrometheusMock{}
+		commandMock = &mcommand.CreateAuthUserCommandMock{}
+	})
+
+	newHandler := func() *handler.CreateAuthUserHandler {
+		return handler.NewCreateAuthUserHandler(commandMock, prometheus, logger, tracer)
+	}
+
+	Context("success cases", func() {
+		It("should record request duration metrics with success status", func() {
+			body := `{"email":"user@example.com","password":"Sup3r$ecret","password_confirm":"Sup3r$ecret","name":"User"}`
+			req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
+			w := httptest.NewRecorder()
+
+			tracer.On("Start", req.Context(), "CreateAuthUserHandler.Handle").Return(req.Context(), adapter.Span(span))
+			span.On("SpanContext").Return(adapter.SpanContext(spanCtx))
+			spanCtx.On("TraceID").Return("trace-123")
+			span.On("End").Return()
+
+			logger.On("InfoJSON", "end request", mock.AnythingOfType("slog.Attr"), mock.AnythingOfType("slog.Attr")).Return()
+
+			output := &dto.CreateAuthUserOutput{ID: 1, PublicID: "user-1", Email: "user@example.com", Name: "User"}
+			commandMock.On("Execute", req.Context(), mock.MatchedBy(func(input dto.CreateAuthUserInput) bool {
+				return input.Email == "user@example.com" && input.Password == "Sup3r$ecret" && input.PasswordConfirm == "Sup3r$ecret" && input.Name == "User"
+			})).Return(output, (*errors.Error)(nil))
+
+			prometheus.On("ObserveRequestDuration", route, "http", http.StatusCreated, "success", mock.MatchedBy(func(value float64) bool {
+				return value >= 0
+			})).Return()
+
+			newHandler().Handle(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+			Expect(prometheus.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(commandMock.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(tracer.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(span.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(spanCtx.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(logger.AssertExpectations(GinkgoT())).To(BeTrue())
+		})
+	})
+
+	Context("error cases", func() {
+		It("should record request duration metrics with decoder error status", func() {
+			req := httptest.NewRequest(http.MethodPost, route, strings.NewReader("invalid"))
+			w := httptest.NewRecorder()
+
+			tracer.On("Start", req.Context(), "CreateAuthUserHandler.Handle").Return(req.Context(), adapter.Span(span))
+			span.On("SpanContext").Return(adapter.SpanContext(spanCtx))
+			spanCtx.On("TraceID").Return("trace-err-1")
+			span.On("RecordError", mock.Anything).Return()
+			span.On("End").Return()
+
+			logger.On("InfoJSON", "end request", mock.AnythingOfType("slog.Attr"), mock.AnythingOfType("slog.Attr")).Return()
+			logger.On("ErrorJSON", "failed decode request body", mock.AnythingOfType("slog.Attr"), mock.AnythingOfType("slog.Attr")).Return()
+
+			prometheus.On("ObserveRequestDuration", route, "http", http.StatusBadRequest, "error", mock.MatchedBy(func(value float64) bool {
+				return value >= 0
+			})).Return()
+
+			newHandler().Handle(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+			Expect(prometheus.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(tracer.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(span.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(spanCtx.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(logger.AssertExpectations(GinkgoT())).To(BeTrue())
+		})
+
+		It("should record request duration metrics with command error status", func() {
+			body := `{"email":"user@example.com","password":"Sup3r$ecret","password_confirm":"Sup3r$ecret","name":"User"}`
+			req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
+			w := httptest.NewRecorder()
+
+			tracer.On("Start", req.Context(), "CreateAuthUserHandler.Handle").Return(req.Context(), adapter.Span(span))
+			span.On("SpanContext").Return(adapter.SpanContext(spanCtx))
+			spanCtx.On("TraceID").Return("trace-err-2")
+			span.On("End").Return()
+
+			logger.On("InfoJSON", "end request", mock.AnythingOfType("slog.Attr"), mock.AnythingOfType("slog.Attr")).Return()
+
+			conflictErr := errors.New(errors.ErrConflict, "conflict")
+			prometheus.On("ObserveRequestDuration", route, "http", http.StatusConflict, "error", mock.MatchedBy(func(value float64) bool {
+				return value >= 0
+			})).Return()
+
+			commandMock.On("Execute", req.Context(), mock.AnythingOfType("dto.CreateAuthUserInput")).Return((*dto.CreateAuthUserOutput)(nil), conflictErr)
+
+			newHandler().Handle(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusConflict))
+			Expect(prometheus.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(commandMock.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(tracer.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(span.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(spanCtx.AssertExpectations(GinkgoT())).To(BeTrue())
+			Expect(logger.AssertExpectations(GinkgoT())).To(BeTrue())
+		})
+	})
+})

--- a/tests/unit/adapter/input/http/handler/suite_test.go
+++ b/tests/unit/adapter/input/http/handler/suite_test.go
@@ -1,0 +1,21 @@
+//go:build unit
+
+package handler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test_CreateAuthUserHandlerSuite(t *testing.T) {
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	suiteConfig.SkipStrings = []string{"SKIPPED", "PENDING", "NEVER-RUN", "SKIP"}
+	reporterConfig.FullTrace = true
+	reporterConfig.Verbose = false
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CreateAuthUserHandler Suite Tests Context", suiteConfig, reporterConfig)
+}


### PR DESCRIPTION
## Summary
- ensure the create auth user handler records durations at observation time and propagates the HTTP status from ResponseError into metrics labels
- return the computed status code from ResponseError so callers can reuse it
- add mocks and unit tests that validate request duration metrics for success, decoder errors, and command errors

## Testing
- GOPROXY=off go test ./...
- GOPROXY=off go test -tags unit ./tests/unit/adapter/input/http/handler -v

------
https://chatgpt.com/codex/tasks/task_e_68fba90fa164832e800ae7ae1a9ac898