### PR TITLE
Rename user service constructor

### DIFF
--- a/internal/app/service/user_service.go
+++ b/internal/app/service/user_service.go
@@ -14,7 +14,7 @@ type UserService struct {
 	log        adapter2.Logger
 }
 
-func NewCustomerService(repository port.UserRepository, trace adapter2.Tracer, log adapter2.Logger) *UserService {
+func NewUserService(repository port.UserRepository, trace adapter2.Tracer, log adapter2.Logger) *UserService {
 	return &UserService{
 		repository: repository,
 		tracer:     trace,

--- a/internal/infra/factory/http/handler/create_auth_user.go
+++ b/internal/infra/factory/http/handler/create_auth_user.go
@@ -39,7 +39,7 @@ func newCreateAuthUser(
 	metrics adapter2.Prometheus,
 ) *command.CreateAuthUser {
 	userRepository := repository.NewUserRepository(db, metrics, tracer)
-	userService := service.NewCustomerService(userRepository, tracer, log)
+	userService := service.NewUserService(userRepository, tracer, log)
 	utils := shared.Utils{}
 	return command.NewCreateAuthUser(
 		userRepository,

--- a/tests/suts/user_service_sut_types.go
+++ b/tests/suts/user_service_sut_types.go
@@ -28,6 +28,6 @@ func MakeUserServiceSut() *UserServiceSut {
 }
 
 func (s *UserServiceSut) Build() *service.UserService {
-	s.Service = service.NewCustomerService(s.Repo, s.Tracer, s.Log)
+	s.Service = service.NewUserService(s.Repo, s.Tracer, s.Log)
 	return s.Service
 }


### PR DESCRIPTION
## Summary
- rename the user service constructor to `NewUserService`
- update factory and test helpers to use the new constructor name
- run unit tests for affected packages

## Testing
- GOPROXY=off go test ./internal/app/service
- GOPROXY=off go test ./internal/infra/factory/http/handler

------
https://chatgpt.com/codex/tasks/task_e_68fba888d1b4832e9c69502b61463200