### PR TITLE
Refactor UnitOfWork for safer transactions and metrics

### DIFF
--- a/internal/infra/uow/unit_of_work.go
+++ b/internal/infra/uow/unit_of_work.go
@@ -2,8 +2,8 @@ package uow
 
 import (
 	"context"
+	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	errors2 "github.com/andreis3/auth-ms/internal/domain/errors"
@@ -13,7 +13,6 @@ import (
 
 type UnitOfWork struct {
 	DB         *pgxpool.Pool
-	TX         pgx.Tx
 	prometheus adapter2.Prometheus
 	tracer     adapter2.Tracer
 }
@@ -31,34 +30,44 @@ func (u *UnitOfWork) WithTransaction(ctx context.Context, fn func(ctx context.Co
 	ctx, span := u.tracer.Start(ctx, "UnitOfWork.WithTransaction")
 	defer func() {
 		span.End()
-		u.TX = nil
 	}()
 
-	if u.TX != nil {
+	start := time.Now()
+	status := "success"
+	defer func() {
+		u.prometheus.ObserveInstructionDBDuration("postgres", "transaction", "with_transaction_"+status, float64(time.Since(start).Milliseconds()))
+	}()
+
+	if _, ok := db.TxFromContext(ctx); ok {
+		status = "error"
 		span.RecordError(errors2.ErrorTransactionAlreadyExists())
 		return errors2.ErrorTransactionAlreadyExists()
 	}
 
 	tx, err := u.DB.Begin(ctx)
 	if err != nil {
+		status = "error"
 		span.RecordError(errors2.ErrorOpeningTransaction(err))
 		return errors2.ErrorOpeningTransaction(err)
 	}
 
-	u.TX = tx
 	ctxTx := db.WithTx(ctx, tx)
 
 	if err := fn(ctxTx); err != nil {
-		rollbackErr := u.TX.Rollback(ctx)
+		status = "error"
+		rollbackErr := tx.Rollback(ctx)
 		if rollbackErr != nil {
-			span.RecordError(errors2.ErrorExecuteRollback(rollbackErr))
-			return errors2.ErrorExecuteRollback(rollbackErr)
+			joinedErr := errors2.Join(err, rollbackErr)
+			rollbackError := errors2.ErrorExecuteRollback(joinedErr)
+			span.RecordError(rollbackError)
+			return rollbackError
 		}
 		span.RecordError(err)
 		return err
 	}
 
-	if err := u.TX.Commit(ctx); err != nil {
+	if err := tx.Commit(ctx); err != nil {
+		status = "error"
 		span.RecordError(errors2.ErrorCommitOrRollback(err))
 		return errors2.ErrorCommitOrRollback(err)
 	}


### PR DESCRIPTION
## Summary
- remove shared transaction state from UnitOfWork and rely on context to guard against nested transactions
- add Prometheus instrumentation to measure transaction duration and join rollback failures with the original error

## Testing
- not run (go test ./... requires external services and did not complete in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fbb47f282c832e853a7977c2ed704c